### PR TITLE
Add widget tests for WeatherList Widget

### DIFF
--- a/lib/utils/testUtils.dart
+++ b/lib/utils/testUtils.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+// This class build method can be used to render widgets with MaterialApp. 
+
+class RenderWithMaterial {
+  RenderWithMaterial();
+  @override
+  Widget build(BuildContext context, Widget child) {
+    return MaterialApp(
+      title: 'Flutter Test',
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text('Test'),
+        ),
+        body: Center(
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -48,5 +48,7 @@ void main() {
 
     // the List should display the City name provided
     expect(find.text('Pune'), findsOneWidget);
+    // the List item should display the minimum and maximum temperatures.
+    expect(find.text('Min Temp: 20° Max Temp: 30°'), findsOneWidget);
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,10 +8,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:flutter_template/main.dart';
+import 'package:flutter_template/routes/weather_route.dart';
+
+import 'package:flutter_template/model/weather.dart';
+import 'package:flutter_template/model/consolidated_weather.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+ /*  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(MyApp());
 
@@ -26,5 +29,24 @@ void main() {
     // Verify that our counter has incremented.
     expect(find.text('0'), findsNothing);
     expect(find.text('1'), findsOneWidget);
+  }); */
+  testWidgets('WeatherList should display city name & weather details ', (WidgetTester tester) async {
+    var weatherData = [
+      ConsolidatedWeather( 1, 'test', 'tst', 'NE', 20, 30, 27, 60, 1.008, 99, 1, 60 )];
+    var input = [Weather('Pune', weatherData)];
+    await tester.pumpWidget(MaterialApp(
+      title: 'Flutter Test',
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text('Test'),
+        ),
+        body: Center(
+          child: WeatherList(input),
+        ),
+      ),
+    ));
+
+    // the List should display the City name provided
+    expect(find.text('Pune'), findsOneWidget);
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,46 +5,21 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:flutter_template/utils/testUtils.dart';
 import 'package:flutter_template/routes/weather_route.dart';
-
 import 'package:flutter_template/model/weather.dart';
 import 'package:flutter_template/model/consolidated_weather.dart';
 
 void main() {
- /*  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
-  }); */
   testWidgets('WeatherList should display city name & weather details ', (WidgetTester tester) async {
     var weatherData = [
       ConsolidatedWeather( 1, 'test', 'tst', 'NE', 20, 30, 27, 60, 1.008, 99, 1, 60 )];
     var input = [Weather('Pune', weatherData)];
-    await tester.pumpWidget(MaterialApp(
-      title: 'Flutter Test',
-      home: Scaffold(
-        appBar: AppBar(
-          title: Text('Test'),
-        ),
-        body: Center(
-          child: WeatherList(input),
-        ),
-      ),
-    ));
+    var renderForTest = RenderWithMaterial();
+    var testWidget = renderForTest.build(null,  WeatherList(input));
+    await tester.pumpWidget(testWidget);
 
     // the List should display the City name provided
     expect(find.text('Pune'), findsOneWidget);


### PR DESCRIPTION
## Description
This PR is to add Widget Tests for WeatherList and thereby figure out Widget testing.

**Issue**
Need a `MaterialApp` wrapper to test the Widgets that are children of Classes that use `MaterialApp`.
`WeatherList` Class is a child of `WeatherRoute` which uses `Scaffold` on `WeatherList`.

**Possible Solution**
Added a `testUtil` that wraps the provided child with the `MaterialApp`.
Widgets that are children of Classes that use `MaterialApp` can be tested individually with this util class.
[Transition](https://api.flutter.dev/flutter/widgets/TransitionBuilder.html) `Widget Builder `was used which takes in a `context` (null) and the `child Widget`.

After providing all the necessary constructor parameters, the Widget is rendered with MaterialApp --

```
    var renderForTest = RenderWithMaterial();
    var testWidget = renderForTest.build(null,  WeatherList(input));
```

**Running flutter test**
![v1](https://user-images.githubusercontent.com/62387714/88965446-65b6ea80-d2c8-11ea-865f-0b221701188f.gif)
